### PR TITLE
UniqueNickNameValidatorのvalidateメソッドを修正

### DIFF
--- a/src/main/java/com/dining/boyaki/controller/AccountInfoController.java
+++ b/src/main/java/com/dining/boyaki/controller/AccountInfoController.java
@@ -1,6 +1,5 @@
 package com.dining.boyaki.controller;
 
-import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -33,7 +32,6 @@ public class AccountInfoController {
 	
 	@InitBinder
 	public void initBinder(WebDataBinder binder) {
-		binder.registerCustomEditor(String.class, new StringTrimmerEditor(true));
 		binder.addValidators(uniqueNickNameValidator);
 	}
 	

--- a/src/main/java/com/dining/boyaki/model/form/AccountInfoForm.java
+++ b/src/main/java/com/dining/boyaki/model/form/AccountInfoForm.java
@@ -1,13 +1,12 @@
 package com.dining.boyaki.model.form;
 
 import javax.validation.constraints.Size;
-import javax.validation.constraints.NotEmpty;
 
 public class AccountInfoForm {
 	
 	private String userName;
 	
-	@NotEmpty(message="ニックネームは必須項目です")
+	@Size(min=2,max=15,message="ニックネームは2字以上15字以内で作成してください")
 	private String nickName;
 	
 	@Size(max = 50, message="50文字以内で入力してください")

--- a/src/main/java/com/dining/boyaki/model/form/validation/UniqueNickNameValidator.java
+++ b/src/main/java/com/dining/boyaki/model/form/validation/UniqueNickNameValidator.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.form.AccountInfoForm;
 import com.dining.boyaki.model.service.FindDataSharedService;
 
@@ -28,11 +29,18 @@ public class UniqueNickNameValidator implements Validator {
 			return;
 		}
 		
-		String existName = findDataSharedService.findNickName(form.getNickName());
-		if(existName != null) {
-			errors.rejectValue("nickName",
-			                   "AccountInfoForm.nickName",
-			                   "入力されたニックネームは既に使われています");
+		AccountInfo existNames = findDataSharedService.findNickName(form.getNickName());
+		if(existNames != null) {
+			if(existNames.getNickName().equals(form.getNickName()) &&
+			   !existNames.getUserName().equals(form.getUserName())) {
+				errors.rejectValue("nickName",
+				                   "AccountInfoForm.nickName",
+				                   "入力されたニックネームは既に使われています");
+			} else {
+				return;
+			}
+		} else {
+			return;
 		}
 	}
 

--- a/src/main/java/com/dining/boyaki/model/form/validation/UniqueUsernameValidator.java
+++ b/src/main/java/com/dining/boyaki/model/form/validation/UniqueUsernameValidator.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.form.RegisterForm;
 import com.dining.boyaki.model.service.FindDataSharedService;
 
@@ -34,8 +35,8 @@ public class UniqueUsernameValidator implements Validator {
 					           "RegisterForm.userName",
 					           "入力されたユーザ名は既に使われています");
 		} else {
-			existName = findDataSharedService.findNickName(form.getUserName());
-			if(existName != null) {
+			AccountInfo existNickName = findDataSharedService.findNickName(form.getUserName());
+			if(existNickName != null) {
 			errors.rejectValue("userName",
 			                   "RegisterForm.userName",
 			                   "入力されたユーザ名は既に使われています");

--- a/src/main/java/com/dining/boyaki/model/mapper/FindDataMapper.java
+++ b/src/main/java/com/dining/boyaki/model/mapper/FindDataMapper.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.entity.DiaryRecord;
 
 @Mapper
@@ -16,6 +17,6 @@ public interface FindDataMapper {
 	DiaryRecord findOneDiaryRecord(@Param("userName")String userName,
                                    @Param("categoryId")int categoryId,
                                    @Param("diaryDay")Date diaryDay);
-	String findNickName(String nickName);
+	AccountInfo findNickName(String nickName);
 
 }

--- a/src/main/java/com/dining/boyaki/model/service/FindDataSharedService.java
+++ b/src/main/java/com/dining/boyaki/model/service/FindDataSharedService.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.entity.DiaryRecord;
 import com.dining.boyaki.model.mapper.FindDataMapper;
 
@@ -38,7 +39,7 @@ public class FindDataSharedService {
 	}
 	
 	@Transactional(readOnly = true)
-	public String findNickName(String userName) {
+	public AccountInfo findNickName(String userName) {
 		return findDataMapper.findNickName(userName);
 	}
 }

--- a/src/main/resources/com/dining/boyaki/model/mapper/FindDataMapper.xml
+++ b/src/main/resources/com/dining/boyaki/model/mapper/FindDataMapper.xml
@@ -41,9 +41,10 @@
         AND DIARYDAY = #{diaryDay}
     </select>
     
-    <select id="findNickName" resultType="String" parameterType="String">
+    <select id="findNickName" resultType="com.dining.boyaki.model.entity.AccountInfo"
+                              parameterType="String">
         SELECT
-            NICKNAME
+            USERNAME,NICKNAME
         FROM
             ACCOUNT_INFO
         WHERE

--- a/src/main/resources/templates/MyPage/MyPage.html
+++ b/src/main/resources/templates/MyPage/MyPage.html
@@ -49,7 +49,7 @@
 	</div>
 </form>
 
-<a id="del"　th:href="@{/index/mypage/delete}">退会する</a>
+<a th:href="@{/index/mypage/inactivate}">退会する</a>
 
 </body>
 </html>

--- a/src/test/java/com/dining/boyaki/model/form/AccountInfoFormTest.java
+++ b/src/test/java/com/dining/boyaki/model/form/AccountInfoFormTest.java
@@ -3,14 +3,29 @@ package com.dining.boyaki.model.form;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DbUnitConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Validator;
 
+import com.dining.boyaki.model.form.validation.UniqueNickNameValidator;
+import com.dining.boyaki.util.CsvDataSetLoader;
+
+@DbUnitConfiguration(dataSetLoader = CsvDataSetLoader.class)
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+                         TransactionalTestExecutionListener.class,
+                         DbUnitTestExecutionListener.class})
 @SpringBootTest
 @Transactional
 public class AccountInfoFormTest {
@@ -18,13 +33,33 @@ public class AccountInfoFormTest {
 	@Autowired
 	Validator validator;
 	
+	@Autowired
+	UniqueNickNameValidator uniqueNickNameValidator;
+	
 	AccountInfoForm form = new AccountInfoForm();
                                                   //ターゲット,ターゲットオブジェクトの名前
 	BindingResult bindingResult = new BindException(form,"AccountInfoForm");
 	
 	@Test
+	@DatabaseSetup(value = "/form/AccountInfo/setup/")
 	void バリデーション問題なし() throws Exception{
-		form.setUserName("マクベイ");
+		form.setUserName("miho");
+		form.setNickName("匿名");
+		form.setProfile("しがない会社員");
+		form.setStatus(0);
+		form.setGender(2);
+		form.setAge(27);
+		
+		validator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
+	}
+	
+	@Test
+	@DatabaseSetup(value = "/form/AccountInfo/setup/")
+	void ニックネームが重複してユーザ名が一緒ならエラーが発生しない() throws Exception{
+		form.setUserName("miho");
 		form.setNickName("mack");
 		form.setProfile("しがない会社員");
 		form.setStatus(0);
@@ -33,22 +68,47 @@ public class AccountInfoFormTest {
 		
 		validator.validate(form, bindingResult);
 		assertEquals(0,bindingResult.getFieldErrorCount());
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
 	}
 	
-	@Test
-	void バリデーション問題あり() throws Exception{
-		form.setUserName("マクベイ");
-		form.setNickName(null);
+	@ParameterizedTest
+	@CsvSource({"亜",
+		        "寿限無寿限無後光の擦り切れ回砂利"})
+	@DatabaseSetup(value = "/form/AccountInfo/setup/")
+	void 指定サイズ範囲外でエラー発生(String nickName) throws Exception{
+		form.setUserName("糸井");
+		form.setNickName(nickName);
 		form.setProfile("123456789012345678901234567890123456789012345678901");
-		form.setStatus(0);
-		form.setGender(1);
-		form.setAge(37);
+		form.setStatus(3);
+		form.setGender(3);
+		form.setAge(21);
 		
 		validator.validate(form, bindingResult);
 		assertEquals(2,bindingResult.getFieldErrorCount());
 		assertTrue(bindingResult.getFieldError("nickName")
-				.toString().contains("ニックネームは必須項目です"));
+				                .toString().contains("ニックネームは2字以上15字以内で作成してください"));
 		assertTrue(bindingResult.getFieldError("profile")
-				.toString().contains("50文字以内で入力してください"));
+				                .toString().contains("50文字以内で入力してください"));
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(2,bindingResult.getFieldErrorCount());
+	}
+	
+	@Test
+	@DatabaseSetup(value = "/form/AccountInfo/setup/")
+	void ニックネームが重複してユーザ名が一致しないならエラーが発生する() throws Exception{
+		form.setUserName("加藤健");
+		form.setNickName("sigeno");
+		form.setProfile("つい最近嫁に小遣いを削られました");
+		form.setStatus(5);
+		form.setGender(1);
+		form.setAge(31);
+		
+		validator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(1,bindingResult.getFieldErrorCount());
+		assertTrue(bindingResult.getFieldError("nickName")
+				                .toString().contains("入力されたニックネームは既に使われています"));
 	}
 }

--- a/src/test/java/com/dining/boyaki/model/form/validation/UniqueNickNameValidatorTest.java
+++ b/src/test/java/com/dining/boyaki/model/form/validation/UniqueNickNameValidatorTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.form.AccountInfoForm;
 import com.dining.boyaki.model.service.FindDataSharedService;
 
@@ -38,6 +39,7 @@ public class UniqueNickNameValidatorTest {
 	
 	@Test
 	void validateでニックネームが重複せずエラーが発生しない() throws Exception{
+		form.setUserName("加藤健");
 		form.setNickName("kenken");
 		when(findDataSharedService.findNickName("kenken")).thenReturn(null);
 		
@@ -47,9 +49,27 @@ public class UniqueNickNameValidatorTest {
 	}
 	
 	@Test
+	void validateでニックネームが重複してユーザ名が一緒ならエラーが発生しない() throws Exception{
+		AccountInfo info = new AccountInfo();
+		info.setUserName("加藤健");
+		info.setNickName("kenken");
+		form.setUserName("加藤健");
+		form.setNickName("kenken");
+		when(findDataSharedService.findNickName("kenken")).thenReturn(info);
+		
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
+		verify(findDataSharedService,times(1)).findNickName("kenken");
+	}
+	
+	@Test
 	void validateでニックネームが重複してエラーが発生する() throws Exception{
+		AccountInfo info = new AccountInfo();
+		info.setUserName("加藤健");
+		info.setNickName("匿名ちゃん");
+		form.setUserName("miho");
 		form.setNickName("匿名ちゃん");
-		when(findDataSharedService.findNickName("匿名ちゃん")).thenReturn("匿名ちゃん");
+		when(findDataSharedService.findNickName("匿名ちゃん")).thenReturn(info);
 		
 		uniqueNickNameValidator.validate(form, bindingResult);
 		assertEquals(1,bindingResult.getFieldErrorCount());

--- a/src/test/java/com/dining/boyaki/model/form/validation/UniqueUsernameValidatorTest.java
+++ b/src/test/java/com/dining/boyaki/model/form/validation/UniqueUsernameValidatorTest.java
@@ -16,8 +16,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 
-import com.dining.boyaki.model.service.FindDataSharedService;
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.form.RegisterForm;
+import com.dining.boyaki.model.service.FindDataSharedService;
 
 @RunWith(SpringRunner.class)
 public class UniqueUsernameValidatorTest {
@@ -64,9 +65,12 @@ public class UniqueUsernameValidatorTest {
 	
 	@Test
 	void validateでニックネームが重複してエラーが発生する() throws Exception{
+		AccountInfo info = new AccountInfo();
+		info.setUserName("糸井");
+		info.setNickName("sigeno");
 		form.setUserName("sigeno");
 		when(findDataSharedService.findUserName("sigeno")).thenReturn(null);
-		when(findDataSharedService.findNickName("sigeno")).thenReturn("sigeno");
+		when(findDataSharedService.findNickName("sigeno")).thenReturn(info);
 		
 		uniqueUsernameValidator.validate(form, bindingResult);
 		assertEquals(1,bindingResult.getFieldErrorCount());

--- a/src/test/java/com/dining/boyaki/model/form/validation/combined/UniqueNickNameValidatorCombinedTest.java
+++ b/src/test/java/com/dining/boyaki/model/form/validation/combined/UniqueNickNameValidatorCombinedTest.java
@@ -44,6 +44,7 @@ public class UniqueNickNameValidatorCombinedTest {
 	@Test
 	@DatabaseSetup(value = "/validation/UniqueNickName/setup/")
 	void validateでニックネームが重複せずエラーが発生しない() throws Exception{
+		form.setUserName("加藤健");
 		form.setNickName("kenken");
 		
 		uniqueNickNameValidator.validate(form, bindingResult);
@@ -52,8 +53,19 @@ public class UniqueNickNameValidatorCombinedTest {
 	
 	@Test
 	@DatabaseSetup(value = "/validation/UniqueNickName/setup/")
+	void validateでニックネームが重複してユーザ名が一緒ならエラーが発生しない() throws Exception{
+		form.setUserName("加藤健");
+		form.setNickName("加藤健");
+		
+		uniqueNickNameValidator.validate(form, bindingResult);
+		assertEquals(0,bindingResult.getFieldErrorCount());
+	}
+	
+	@Test
+	@DatabaseSetup(value = "/validation/UniqueNickName/setup/")
 	void validateでニックネームが重複してエラーが発生する() throws Exception{
-		form.setNickName("匿名");
+		form.setUserName("加藤健");
+		form.setNickName("sigeno");
 		
 		uniqueNickNameValidator.validate(form, bindingResult);
 		assertEquals(1,bindingResult.getFieldErrorCount());

--- a/src/test/java/com/dining/boyaki/model/mapper/FindDataMapperTest.java
+++ b/src/test/java/com/dining/boyaki/model/mapper/FindDataMapperTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.entity.DiaryRecord;
 
 @DbUnitConfiguration(dataSetLoader = CsvDataSetLoader.class)
@@ -80,7 +81,8 @@ public class FindDataMapperTest {
 	@Test
 	@DatabaseSetup(value = "/mapper/FindData/setup/")
 	void findNickNameでニックネームを1人見つける() throws Exception{
-		String userName = findDataMapper.findNickName("sigeno");
-		assertEquals("sigeno",userName);
+		AccountInfo userName = findDataMapper.findNickName("sigeno");
+		assertEquals("糸井",userName.getUserName());
+		assertEquals("sigeno",userName.getNickName());
 	}
 }

--- a/src/test/java/com/dining/boyaki/model/service/FindDataSharedServiceTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/FindDataSharedServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.entity.DiaryRecord;
 import com.dining.boyaki.model.mapper.FindDataMapper;
 
@@ -119,16 +120,20 @@ public class FindDataSharedServiceTest {
 	
 	@Test
 	void findNickNameでニックネームを取得する() throws Exception{
-		when(findDataMapper.findNickName("sigeno")).thenReturn("sigeno");
-		String userName = findDataSharedService.findNickName("sigeno");
-		assertEquals("sigeno",userName);
+		AccountInfo info = new AccountInfo();
+		info.setUserName("糸井");
+		info.setNickName("sigeno");
+		when(findDataMapper.findNickName("sigeno")).thenReturn(info);
+		AccountInfo userName = findDataSharedService.findNickName("sigeno");
+		assertEquals("糸井",userName.getUserName());
+		assertEquals("sigeno",userName.getNickName());
 		verify(findDataMapper,times(1)).findNickName("sigeno");
 	}
 	
 	@Test
 	void findNickNameでニックネームが見つからない場合はNullが返ってくる() throws Exception{
 		when(findDataMapper.findNickName("hogei")).thenReturn(null);
-		String userName = findDataSharedService.findNickName("hogei");
+		AccountInfo userName = findDataSharedService.findNickName("hogei");
 		assertNull(userName);
 		verify(findDataMapper,times(1)).findNickName("hogei");
 	}

--- a/src/test/java/com/dining/boyaki/model/service/conbined/FindDataSharedServiceCombinedTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/conbined/FindDataSharedServiceCombinedTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dining.boyaki.model.entity.AccountInfo;
 import com.dining.boyaki.model.entity.DiaryRecord;
 import com.dining.boyaki.model.service.FindDataSharedService;
 import com.dining.boyaki.util.CsvDataSetLoader;
@@ -100,15 +101,16 @@ public class FindDataSharedServiceCombinedTest {
 	@Test
 	@DatabaseSetup(value = "/service/FindData/setup/")
 	void findNickNameでニックネームを取得する() throws Exception{
-		String userName = findDataSharedService.findNickName("sigeno");
-		assertEquals("sigeno",userName);
+		AccountInfo info = findDataSharedService.findNickName("sigeno");
+		assertEquals("糸井",info.getUserName());
+		assertEquals("sigeno",info.getNickName());
 	}
 	
 	@Test
 	@DatabaseSetup(value = "/service/FindData/setup/")
 	void findNickNameでニックネームが見つからない場合はNullが返ってくる() throws Exception{
-		String userName = findDataSharedService.findNickName("hogei");
-		assertNull(userName);
+		AccountInfo info = findDataSharedService.findNickName("hogei");
+		assertNull(info);
 	}
 
 }

--- a/src/test/resources/form/AccountInfo/setup/account.csv
+++ b/src/test/resources/form/AccountInfo/setup/account.csv
@@ -1,0 +1,5 @@
+username,password,mail,role
+"admin", "select*fomUser","admin@softbank",     "ROLE_ADMIN"
+"miho",  "ocean-Nu",      "miho@gmail.com",     "ROLE_USER"
+"加藤健","pinballs",      "example@ezweb.ne.jp","ROLE_USER"
+"糸井",  "sigeSIGE",      "mother@yahoo.co.jp", "ROLE_USER"

--- a/src/test/resources/form/AccountInfo/setup/account_info.csv
+++ b/src/test/resources/form/AccountInfo/setup/account_info.csv
@@ -1,0 +1,4 @@
+username,nickname,profile,status,gender,age
+加藤健,加藤健,つい最近嫁に小遣いを削られました,5,1,31
+miho,匿名,5000兆円欲しい！！！,0,2,27
+糸井,sigeno,今年中に体重5キロ落としたい,3,3,21

--- a/src/test/resources/form/AccountInfo/setup/table-ordering.txt
+++ b/src/test/resources/form/AccountInfo/setup/table-ordering.txt
@@ -1,0 +1,2 @@
+account
+account_info


### PR DESCRIPTION
ニックネームの重複を確認する際に、ユーザ名も確認するように処理を修正