### PR TITLE
chabgeEntitySharedServiceを修正 #27

### DIFF
--- a/src/main/java/com/dining/boyaki/model/service/AccountInfoService.java
+++ b/src/main/java/com/dining/boyaki/model/service/AccountInfoService.java
@@ -56,14 +56,7 @@ public class AccountInfoService {
 		if(Objects.isNull(info)) {
     		return null;
     	}
-		AccountInfoForm form = new AccountInfoForm();
-		form.setUserName(info.getUserName());
-		form.setNickName(info.getNickName());
-		form.setProfile(info.getProfile());
-		form.setStatus(info.getStatus());
-		form.setAge(info.getAge());
-		form.setGender(info.getGender());
-    	return form;
+    	return setToAccountInfoForm(info);
 	}
 	
 	@Transactional(readOnly = false)

--- a/src/main/java/com/dining/boyaki/model/service/AccountInfoService.java
+++ b/src/main/java/com/dining/boyaki/model/service/AccountInfoService.java
@@ -20,6 +20,28 @@ public class AccountInfoService {
 	
 	private final PasswordEncoder passwordEncoder;
 	
+	public AccountInfoForm setToAccountInfoForm(AccountInfo info) {
+		AccountInfoForm form = new AccountInfoForm();
+		form.setUserName(info.getUserName());
+		form.setNickName(info.getNickName());
+		form.setProfile(info.getProfile());
+		form.setStatus(info.getStatus());
+		form.setAge(info.getAge());
+		form.setGender(info.getGender());
+		return form;
+	}
+	
+	public AccountInfo setToAccountInfo(AccountInfoForm form) {
+		AccountInfo info = new AccountInfo();
+		info.setUserName(form.getUserName());
+		info.setNickName(form.getNickName());
+		info.setProfile(form.getProfile());
+		info.setStatus(form.getStatus());
+		info.setGender(form.getGender());
+		info.setAge(form.getAge());
+		return info;
+	}
+	
 	public AccountInfoService(AccountInfoMapper accountInfoMapper,
 			                  ChangeEntitySharedService changeEntitySharedService,
 			                  PasswordEncoder passwordEncoder) {
@@ -34,12 +56,19 @@ public class AccountInfoService {
 		if(Objects.isNull(info)) {
     		return null;
     	}
-    	return changeEntitySharedService.setToAccountInfoForm(info);
+		AccountInfoForm form = new AccountInfoForm();
+		form.setUserName(info.getUserName());
+		form.setNickName(info.getNickName());
+		form.setProfile(info.getProfile());
+		form.setStatus(info.getStatus());
+		form.setAge(info.getAge());
+		form.setGender(info.getGender());
+    	return form;
 	}
 	
 	@Transactional(readOnly = false)
 	public void updateAccountInfo(AccountInfoForm form) {
-		accountInfoMapper.updateAccountInfo(changeEntitySharedService.setToAccountInfo(form));
+		accountInfoMapper.updateAccountInfo(setToAccountInfo(form));
 	}
 	
 	@Transactional(readOnly = false)

--- a/src/main/java/com/dining/boyaki/model/service/ChangeEntitySharedService.java
+++ b/src/main/java/com/dining/boyaki/model/service/ChangeEntitySharedService.java
@@ -4,11 +4,8 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import com.dining.boyaki.model.entity.Account;
 import com.dining.boyaki.model.entity.AccountInfo;
-import com.dining.boyaki.model.entity.DiaryRecord;
 import com.dining.boyaki.model.entity.PasswordHistory;
-import com.dining.boyaki.model.form.AccountInfoForm;
 import com.dining.boyaki.model.form.PasswordChangeForm;
-import com.dining.boyaki.model.form.DiaryRecordForm;
 import com.dining.boyaki.model.form.RegisterForm;
 
 @Service
@@ -56,56 +53,6 @@ public class ChangeEntitySharedService {
 		info.setGender(0);
 		info.setAge(0);
 		return info;
-	}
-	
-	public AccountInfo setToAccountInfo(AccountInfoForm form) {
-		AccountInfo info = new AccountInfo();
-		info.setUserName(form.getUserName());
-		info.setNickName(form.getNickName());
-		info.setProfile(form.getProfile());
-		info.setStatus(form.getStatus());
-		info.setGender(form.getGender());
-		info.setAge(form.getAge());
-		return info;
-	}
-	
-	public DiaryRecord setToDiaryRecord(DiaryRecordForm form) {
-		DiaryRecord record = new DiaryRecord();
-		record.setUserName(form.getUserName());
-		record.setCategoryId(form.getCategoryId());
-		record.setDiaryDay(form.getDiaryDay());
-		record.setRecord1(form.getRecord1());
-		record.setRecord2(form.getRecord2());
-		record.setRecord3(form.getRecord3());
-		record.setPrice(form.getPrice());
-		record.setMemo(form.getMemo());
-		record.setCreateAt(form.getCreateAt());
-		return record;
-	}
-	
-	public DiaryRecordForm setToDiaryRecordForm(DiaryRecord record) {
-		DiaryRecordForm form = new DiaryRecordForm();
-		form.setUserName(record.getUserName());
-		form.setCategoryId(record.getCategoryId());
-		form.setDiaryDay(record.getDiaryDay());
-		form.setRecord1(record.getRecord1());
-		form.setRecord2(record.getRecord2());
-		form.setRecord3(record.getRecord3());
-		form.setPrice(record.getPrice());
-		form.setMemo(record.getMemo());
-		form.setCreateAt(record.getCreateAt());
-		return form;
-	}
-	
-	public AccountInfoForm setToAccountInfoForm(AccountInfo info) {
-		AccountInfoForm form = new AccountInfoForm();
-		form.setUserName(info.getUserName());
-		form.setNickName(info.getNickName());
-		form.setProfile(info.getProfile());
-		form.setStatus(info.getStatus());
-		form.setAge(info.getAge());
-		form.setGender(info.getGender());
-		return form;
 	}
 
 }

--- a/src/main/java/com/dining/boyaki/model/service/DiaryRecordService.java
+++ b/src/main/java/com/dining/boyaki/model/service/DiaryRecordService.java
@@ -19,12 +19,36 @@ public class DiaryRecordService {
 	
 	private final DiaryRecordMapper diaryRecordMapper;
 	
-	private final ChangeEntitySharedService changeEntitySharedService;
-	
-	public DiaryRecordService(DiaryRecordMapper diaryRecordMapper,
-			                  ChangeEntitySharedService changeEntitySharedService) {
+	public DiaryRecordService(DiaryRecordMapper diaryRecordMapper) {
 		this.diaryRecordMapper = diaryRecordMapper;
-		this.changeEntitySharedService = changeEntitySharedService;
+	}
+	
+	public DiaryRecord setToDiaryRecord(DiaryRecordForm form) {
+		DiaryRecord record = new DiaryRecord();
+		record.setUserName(form.getUserName());
+		record.setCategoryId(form.getCategoryId());
+		record.setDiaryDay(form.getDiaryDay());
+		record.setRecord1(form.getRecord1());
+		record.setRecord2(form.getRecord2());
+		record.setRecord3(form.getRecord3());
+		record.setPrice(form.getPrice());
+		record.setMemo(form.getMemo());
+		record.setCreateAt(form.getCreateAt());
+		return record;
+	}
+	
+	public DiaryRecordForm setToDiaryRecordForm(DiaryRecord record) {
+		DiaryRecordForm form = new DiaryRecordForm();
+		form.setUserName(record.getUserName());
+		form.setCategoryId(record.getCategoryId());
+		form.setDiaryDay(record.getDiaryDay());
+		form.setRecord1(record.getRecord1());
+		form.setRecord2(record.getRecord2());
+		form.setRecord3(record.getRecord3());
+		form.setPrice(record.getPrice());
+		form.setMemo(record.getMemo());
+		form.setCreateAt(record.getCreateAt());
+		return form;
 	}
 	
 	@Transactional(readOnly = true)
@@ -82,13 +106,13 @@ public class DiaryRecordService {
     	if(Objects.isNull(diary)) {
     		return null;
     	}
-    	return changeEntitySharedService.setToDiaryRecordForm(diary);
+    	return setToDiaryRecordForm(diary);
     	
     }
     
     @Transactional(readOnly = false)
     public void insertDiaryRecord(DiaryRecordForm form) {
-    	DiaryRecord diary = changeEntitySharedService.setToDiaryRecord(form);
+    	DiaryRecord diary = setToDiaryRecord(form);
     	diary.setCreateAt(LocalDateTime.now());
     	diary.setUpdateAt(diary.getCreateAt());
     	diaryRecordMapper.insertDiaryRecord(diary);
@@ -96,14 +120,14 @@ public class DiaryRecordService {
     
     @Transactional(readOnly = false)
     public void updateDiaryRecord(DiaryRecordForm form) {
-    	DiaryRecord diary = changeEntitySharedService.setToDiaryRecord(form);
+    	DiaryRecord diary = setToDiaryRecord(form);
     	diary.setUpdateAt(LocalDateTime.now());
     	diaryRecordMapper.updateDiaryRecord(diary);
     }
     
     @Transactional(readOnly = false)
     public void deleteDiaryRecord(DiaryRecordForm form) {
-    	diaryRecordMapper.deleteDiaryRecord(changeEntitySharedService.setToDiaryRecord(form));
+    	diaryRecordMapper.deleteDiaryRecord(setToDiaryRecord(form));
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/boyaki_dining
 spring.datasource.username=boyakiUser
 spring.datasource.password=nyousanti
 spring.datasource.driver-class-name =com.mysql.cj.jdbc.Driver
+spring.jpa.open-in-view= true

--- a/src/test/java/com/dining/boyaki/model/service/AccountInfoServiceTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/AccountInfoServiceTest.java
@@ -1,6 +1,7 @@
 package com.dining.boyaki.model.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,6 +47,44 @@ public class AccountInfoServiceTest {
 		MockitoAnnotations.openMocks(this);
 	}
 	
+	@Test
+    void setToAccountInfoFormでAccountInfoをAccountInfoFormに詰め替える() throws Exception{
+		AccountInfo info = new AccountInfo();
+		info.setUserName("miho");
+		info.setNickName("匿名ちゃん");
+		info.setProfile("毎日定時で帰りたい");
+		info.setStatus(0);
+		info.setGender(2);
+		info.setAge(21);
+		
+		AccountInfoForm form = accountInfoService.setToAccountInfoForm(info);
+		assertEquals("miho",form.getUserName());
+		assertEquals("匿名ちゃん",form.getNickName());
+		assertEquals("毎日定時で帰りたい",form.getProfile());
+		assertEquals(0,form.getStatus());
+		assertEquals(2,form.getGender());
+		assertEquals(21,form.getAge());
+	}
+	
+	@Test
+    void setToAccountInfoでAccountInfoFormをAccountInfoに詰め替える() throws Exception{
+		AccountInfoForm form = new AccountInfoForm();
+		form.setUserName("miho");
+		form.setNickName("匿名ちゃん");
+		form.setProfile("毎日定時で帰りたい");
+		form.setStatus(0);
+		form.setGender(2);
+		form.setAge(21);
+		
+		AccountInfo info = accountInfoService.setToAccountInfo(form);
+		assertEquals("miho",info.getUserName());
+		assertEquals("匿名ちゃん",info.getNickName());
+		assertEquals("毎日定時で帰りたい",info.getProfile());
+		assertEquals(0,info.getStatus());
+		assertEquals(2,info.getGender());
+		assertEquals(21,info.getAge());
+	}
+	
 	@Nested
 	class AccountInfoMethods {
 		AccountInfo info;
@@ -72,7 +111,6 @@ public class AccountInfoServiceTest {
 		@Test
 		void findAccountInfoでユーザ情報レコードを1件取得する() {
 			when(accountInfoMapper.findAccountInfo("糸井")).thenReturn(info);
-			when(changeEntitySharedService.setToAccountInfoForm(info)).thenReturn(form);
 			
 			AccountInfoForm result =  accountInfoService.findAccountInfo("糸井");
 			assertEquals("糸井",result.getUserName());
@@ -82,28 +120,23 @@ public class AccountInfoServiceTest {
 			assertEquals(3,result.getGender());
 			assertEquals(2,result.getAge());
 			verify(accountInfoMapper,times(1)).findAccountInfo("糸井");
-			verify(changeEntitySharedService,times(1)).setToAccountInfoForm(info);
 		}
 	
 		@Test
 		void findAccountInfoでユーザ情報レコードが取得できない場合はnullが返ってくる() {
 			when(accountInfoMapper.findAccountInfo("糸井")).thenReturn(null);
-			when(changeEntitySharedService.setToAccountInfoForm(info)).thenReturn(form);
 			
 			AccountInfoForm result =  accountInfoService.findAccountInfo("糸井");
 			assertEquals(null,result);
 			verify(accountInfoMapper,times(1)).findAccountInfo("糸井");
-			verify(changeEntitySharedService,times(0)).setToAccountInfoForm(info);
 		}
 		
 		@Test
 		void updateAccountInfoでユーザ情報レコードを更新する() {
-			when(changeEntitySharedService.setToAccountInfo(form)).thenReturn(info);
-			doNothing().when(accountInfoMapper).updateAccountInfo(info);
+			doNothing().when(accountInfoMapper).updateAccountInfo(any(AccountInfo.class));
 			
 			accountInfoService.updateAccountInfo(form);
-			verify(changeEntitySharedService,times(1)).setToAccountInfo(form);
-			verify(accountInfoMapper,times(1)).updateAccountInfo(info);
+			verify(accountInfoMapper,times(1)).updateAccountInfo(any(AccountInfo.class));
 		}
 	}
 	

--- a/src/test/java/com/dining/boyaki/model/service/ChangeEntitySharedServiceTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/ChangeEntitySharedServiceTest.java
@@ -2,7 +2,6 @@ package com.dining.boyaki.model.service;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.Date;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,10 +13,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import com.dining.boyaki.model.entity.Account;
 import com.dining.boyaki.model.entity.AccountInfo;
-import com.dining.boyaki.model.entity.DiaryRecord;
 import com.dining.boyaki.model.entity.PasswordHistory;
-import com.dining.boyaki.model.form.AccountInfoForm;
-import com.dining.boyaki.model.form.DiaryRecordForm;
 import com.dining.boyaki.model.form.PasswordChangeForm;
 import com.dining.boyaki.model.form.RegisterForm;
 
@@ -116,94 +112,6 @@ public class ChangeEntitySharedServiceTest {
 		assertEquals(0,info.getStatus());
 		assertEquals(0,info.getGender());
 		assertEquals(0,info.getAge());
-	}
-	
-	@Test
-    void setToAccountInfoでAccountInfoFormをAccountInfoに詰め替える() throws Exception{
-		AccountInfoForm form = new AccountInfoForm();
-		form.setUserName("miho");
-		form.setNickName("匿名ちゃん");
-		form.setProfile("毎日定時で帰りたい");
-		form.setStatus(0);
-		form.setGender(2);
-		form.setAge(21);
-		
-		AccountInfo info = changeEntitySharedService.setToAccountInfo(form);
-		assertEquals("miho",info.getUserName());
-		assertEquals("匿名ちゃん",info.getNickName());
-		assertEquals("毎日定時で帰りたい",info.getProfile());
-		assertEquals(0,info.getStatus());
-		assertEquals(2,info.getGender());
-		assertEquals(21,info.getAge());
-	}
-	
-	@Test
-    void setToAccountInfoFormでAccountInfoをAccountInfoFormに詰め替える() throws Exception{
-		AccountInfo info = new AccountInfo();
-		info.setUserName("miho");
-		info.setNickName("匿名ちゃん");
-		info.setProfile("毎日定時で帰りたい");
-		info.setStatus(0);
-		info.setGender(2);
-		info.setAge(21);
-		
-		AccountInfoForm form = changeEntitySharedService.setToAccountInfoForm(info);
-		assertEquals("miho",form.getUserName());
-		assertEquals("匿名ちゃん",form.getNickName());
-		assertEquals("毎日定時で帰りたい",form.getProfile());
-		assertEquals(0,form.getStatus());
-		assertEquals(2,form.getGender());
-		assertEquals(21,form.getAge());
-	}
-	
-	@Test
-    void setToDiaryRecordでDiaryRecordFormをDiaryRecordに詰め替える() throws Exception{
-		DiaryRecordForm form = new DiaryRecordForm();
-		form.setUserName("糸井");
-		form.setCategoryId(3);
-		form.setDiaryDay(Date.valueOf("2022-02-04"));
-		form.setRecord1("冷麺");
-		form.setRecord2("焼肉");
-		form.setRecord3("もやしナムル");
-		form.setPrice(2980);
-		form.setMemo("焼肉屋で外食");
-		form.setCreateAt(datetime);
-		
-		DiaryRecord record = changeEntitySharedService.setToDiaryRecord(form);
-		assertEquals("糸井",record.getUserName());
-		assertEquals(3,record.getCategoryId());
-		assertEquals(Date.valueOf("2022-02-04"),record.getDiaryDay());
-		assertEquals("冷麺",record.getRecord1());
-		assertEquals("焼肉",record.getRecord2());
-		assertEquals("もやしナムル",record.getRecord3());
-		assertEquals(2980,record.getPrice());
-		assertEquals("焼肉屋で外食",record.getMemo());
-		assertEquals(datetime,record.getCreateAt());
-	}
-	
-	@Test
-    void setToDiaryRecordFormでDiaryRecordをDiaryRecordFormに詰め替える() throws Exception{
-		DiaryRecord record = new DiaryRecord();
-		record.setUserName("糸井");
-		record.setCategoryId(3);
-		record.setDiaryDay(Date.valueOf("2022-02-04"));
-		record.setRecord1("冷麺");
-		record.setRecord2("焼肉");
-		record.setRecord3("もやしナムル");
-		record.setPrice(2980);
-		record.setMemo("焼肉屋で外食");
-		record.setCreateAt(datetime);
-		
-		DiaryRecordForm form = changeEntitySharedService.setToDiaryRecordForm(record);
-		assertEquals("糸井",form.getUserName());
-		assertEquals(3,form.getCategoryId());
-		assertEquals(Date.valueOf("2022-02-04"),form.getDiaryDay());
-		assertEquals("冷麺",form.getRecord1());
-		assertEquals("焼肉",form.getRecord2());
-		assertEquals("もやしナムル",form.getRecord3());
-		assertEquals(2980,form.getPrice());
-		assertEquals("焼肉屋で外食",form.getMemo());
-		assertEquals(datetime,form.getCreateAt());
 	}
 	
 }


### PR DESCRIPTION
ChangeEntitySharedServiceのメソッドを、ユーザ登録時・パスワード変更時のものだけに修正。
DiaryRecordServiceとAccountInfoServiceに、それぞれエンティティを詰め替えるメソッドを追加。
Serviceクラスのテストコードを修正