### PR TITLE
ConfirmFileUploadValidatorを修正 #62

### DIFF
--- a/src/main/java/com/dining/boyaki/model/form/validation/ConfirmFileUpload.java
+++ b/src/main/java/com/dining/boyaki/model/form/validation/ConfirmFileUpload.java
@@ -15,7 +15,7 @@ import javax.validation.Payload;
 @Retention(RetentionPolicy.RUNTIME) //アノテーションの読み込みタイミング
 public @interface ConfirmFileUpload {
 	
-	String message() default "ファイルサイズが大きすぎるか、ファイル形式が不正です。";
+	String message() default "ファイル拡張子がjpg,jpegであることを確認してください";
 	Class<?>[] groups() default {};
 	Class<? extends Payload>[] payload() default {};
 	

--- a/src/main/java/com/dining/boyaki/model/form/validation/ConfirmFileUploadValidator.java
+++ b/src/main/java/com/dining/boyaki/model/form/validation/ConfirmFileUploadValidator.java
@@ -17,17 +17,12 @@ public class ConfirmFileUploadValidator implements ConstraintValidator<ConfirmFi
 			return true;
 		}
 		
-		//ファイルサイズの確認、10MB以上ならエラー
-		if(10485760 <= multipartFile.getSize()) {
-			return false;
-		}
-		
 		//メディアタイプ、拡張子の確認
 		MediaType mediaType = MediaType.parseMediaType(multipartFile.getContentType());
 		String extension = FilenameUtils.getExtension(multipartFile.getOriginalFilename());
 		
-		List<MediaType> mediaTypeList = Arrays.asList(MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG , MediaType.MULTIPART_FORM_DATA);
-	    List<String> extList = Arrays.asList("jpg", "jpeg", "png");
+		List<MediaType> mediaTypeList = Arrays.asList(MediaType.IMAGE_JPEG,MediaType.MULTIPART_FORM_DATA);
+	    List<String> extList = Arrays.asList("jpg", "jpeg");
 	    
 	    return  mediaTypeList.stream().anyMatch((mType) -> mediaType.includes(mType))
 	                        && extList.stream().anyMatch((v) -> extension.toLowerCase().equals(v));

--- a/src/test/java/com/dining/boyaki/model/form/FileUploadFormTest.java
+++ b/src/test/java/com/dining/boyaki/model/form/FileUploadFormTest.java
@@ -35,7 +35,7 @@ public class FileUploadFormTest {
     	validator.validate(form, bindingResult);
     	assertEquals(0,bindingResult.getFieldErrorCount());
     	
-    	//サイズ、形式が問題ない場合
+    	//形式が問題ない場合
     	File upFile = new File("src/test/resources/image/3840_2160.jpg");
 		Path path = Paths.get(upFile.getCanonicalPath());
 		byte[] bytes = Files.readAllBytes(path);
@@ -47,39 +47,23 @@ public class FileUploadFormTest {
     }
     
     @Test
-    void ファイルサイズ超過でバリデーションエラー発生() throws Exception{
-    	File upFile = new File("src/test/resources/image/6760135001_14c59a1490_o.jpg");
-		Path path = Paths.get(upFile.getCanonicalPath());
-		byte[] bytes = Files.readAllBytes(path);
-		MultipartFile file = new MockMultipartFile("file","6760135001_14c59a1490_o.jpg","multipart/form-data",bytes);
-    	
-    	form.setMultipartFile(file);
-    	
-    	validator.validate(form, bindingResult);
-    	assertEquals(1,bindingResult.getFieldErrorCount());
-    	assertTrue(bindingResult.getFieldError("multipartFile")
-    			                .toString().contains("ファイルサイズが大きすぎるか、ファイル形式が不正です。"));
-    	
-    }
-    
-    @Test
     void メディアタイプやでバリデーションエラー発生() throws Exception{
     	File upFile = new File("src/test/resources/image/testApp.js");
 		Path path = Paths.get(upFile.getCanonicalPath());
 		byte[] bytes = Files.readAllBytes(path);
-		MultipartFile file = new MockMultipartFile("file","testApp.js","multipart/form-data",bytes);
+		MultipartFile file = new MockMultipartFile("file","testApp.js","text/javascript",bytes);
     	form.setMultipartFile(file);
     	validator.validate(form, bindingResult);
     	assertEquals(1,bindingResult.getFieldErrorCount());
     	assertTrue(bindingResult.getFieldError("multipartFile")
-    			                .toString().contains("ファイルサイズが大きすぎるか、ファイル形式が不正です。"));
+    			                .toString().contains("ファイル拡張子がjpg,jpegであることを確認してください"));
     	
-    	file = new MockMultipartFile("file","testApp.png","text/javascript",bytes);
+    	file = new MockMultipartFile("file","testApp.png","multipart/form-data",bytes);
     	form.setMultipartFile(file);
     	validator.validate(form, bindingResult);
     	assertEquals(2,bindingResult.getFieldErrorCount());
     	assertTrue(bindingResult.getFieldError("multipartFile")
-    			                .toString().contains("ファイルサイズが大きすぎるか、ファイル形式が不正です。"));
+    			                .toString().contains("ファイル拡張子がjpg,jpegであることを確認してください"));
     }
 
 }


### PR DESCRIPTION
ConfirmFileUploadValidatorを修正(jpg,jpegのみ受け付けるように修正、ファイルサイズの確認は削除)
FileUploadFormのテストコードを修正