### PR TITLE
ログイン時の認証をユーザ名からメールアドレスに変更 #86

### DIFF
--- a/src/main/java/com/dining/boyaki/config/WebSecurityConfig.java
+++ b/src/main/java/com/dining/boyaki/config/WebSecurityConfig.java
@@ -40,7 +40,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     	http.formLogin()
     	    .loginPage("/login")
     	    .loginProcessingUrl("/authenticate")
-    	    .usernameParameter("username")
+    	    .usernameParameter("mail")
     	    .passwordParameter("password")
     	    .successHandler(successHandler)
     	    .failureUrl("/login?error")

--- a/src/main/java/com/dining/boyaki/model/mapper/LoginMapper.java
+++ b/src/main/java/com/dining/boyaki/model/mapper/LoginMapper.java
@@ -6,6 +6,6 @@ import com.dining.boyaki.model.entity.Account;
 @Mapper
 public interface LoginMapper {
 	
-	Account findAccount(String userName);
+	Account findAccount(String mail);
 
 }

--- a/src/main/java/com/dining/boyaki/model/service/AccountUserDetailsService.java
+++ b/src/main/java/com/dining/boyaki/model/service/AccountUserDetailsService.java
@@ -24,8 +24,8 @@ public class AccountUserDetailsService implements UserDetailsService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		Account account = Optional.ofNullable(loginMapper.findAccount(username))
+	public UserDetails loadUserByUsername(String mail) throws UsernameNotFoundException {
+		Account account = Optional.ofNullable(loginMapper.findAccount(mail))
 				                  .orElseThrow(() -> new UsernameNotFoundException("User not found."));
 		                                    //オーソリティをGrantedAuthorityオブジェクトのリストに変換
 		return new AccountUserDetails(account,AuthorityUtils.createAuthorityList(account.getRole()));

--- a/src/main/resources/com/dining/boyaki/model/mapper/LoginMapper.xml
+++ b/src/main/resources/com/dining/boyaki/model/mapper/LoginMapper.xml
@@ -12,7 +12,7 @@
         from
             account
         where
-           username = #{userName}
+           mail = #{mail}
     </select>
     
 </mapper>

--- a/src/main/resources/templates/Login/Login.html
+++ b/src/main/resources/templates/Login/Login.html
@@ -17,10 +17,10 @@
 	    <div class="col-sm-6">
 		    <div class="row card forms">
 				<div class="form-group">
-					<label for="username">ユーザ名</label>
+					<label for="username">メールアドレス</label>
 					<div>
-					    <input type="text" id="username" name="username" class="form-control" 
-					           placeholder="ユーザ名を入力してください">
+					    <input type="email" id="mail" name="mail" class="form-control" 
+					           placeholder="メールアドレスを入力してください">
 					</div>
 				</div><br>
 				<div class="form-group">
@@ -40,7 +40,7 @@
 	</form>
 	<div class="form-button col-sm-6">
 		<form class="row form-button" th:action="@{/authenticate}" method="post">
-			<input type="hidden" id="gestuser" name="username" value="guestuser">
+			<input type="hidden" id="gestuser" name="mail" value="guest@gmail.com">
 			<input type="hidden" id="gestpass" name="password" value="gesugesudegesu">
 			<div>
 				<button class="btn btn-green" type="submit">ゲストログイン</button>

--- a/src/test/java/com/dining/boyaki/controller/LoginControllerTest.java
+++ b/src/test/java/com/dining/boyaki/controller/LoginControllerTest.java
@@ -88,7 +88,7 @@ public class LoginControllerTest {
     @DatabaseSetup(value="/controller/Login/setup/")
 	void ROLE_USERがログインに成功するとUSER用のトップ画面が表示される() throws Exception{
     	this.mockMvc.perform(formLogin("/authenticate")
-	                        .user("username", "加藤健")
+	                        .user("mail", "example@ezweb.ne.jp")
 	                        .password("password","pinballs")
                              )
     	            .andExpect(authenticated())
@@ -100,7 +100,7 @@ public class LoginControllerTest {
     @DatabaseSetup(value="/controller/Login/setup/")
 	void ROLE_ADMINがログインに成功するとADMIN用のトップ画面が表示される() throws Exception{
     	this.mockMvc.perform(formLogin("/authenticate")
-	                        .user("username", "admin")
+	                        .user("mail", "admin@softbank")
 	                        .password("password","select*fromUser")
                              )
     	            .andExpect(authenticated())
@@ -109,12 +109,12 @@ public class LoginControllerTest {
     }
     
     @ParameterizedTest
-	@CsvSource({"admin,select*fromuser",
-		        "鈴木純也,zyunnzyunn"})
+	@CsvSource({"admin@softbank,select*fromuser",
+		        "hogehoge@gmail.com,zyunnzyunn"})
     @DatabaseSetup(value="/controller/Login/setup/")
-	void PWを間違えたりDBに登録されていないユーザはログインできない(String username,String password) throws Exception{
+	void PWを間違えたりDBに登録されていないユーザはログインできない(String mail,String password) throws Exception{
     	this.mockMvc.perform(formLogin("/authenticate")
-	                        .user("username", username)
+	                        .user("mail", mail)
 	                        .password("password",password)
                             )
     	            .andExpect(unauthenticated())

--- a/src/test/java/com/dining/boyaki/model/mapper/LoginMapperTest.java
+++ b/src/test/java/com/dining/boyaki/model/mapper/LoginMapperTest.java
@@ -40,7 +40,7 @@ public class LoginMapperTest {
 	@Test
 	@DatabaseSetup(value = "/mapper/Login/setup/")
 	void findAccountでユーザを一人見つける() throws Exception{
-		Account existAccount = loginMapper.findAccount("加藤健");
+		Account existAccount = loginMapper.findAccount("example@ezweb.ne.jp");
 		assertEquals("加藤健",existAccount.getUserName());
 		assertEquals("pinballs",existAccount.getPassword());
 		assertEquals("ROLE_USER",existAccount.getRole());

--- a/src/test/java/com/dining/boyaki/model/service/AccountUserDetailsServiceTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/AccountUserDetailsServiceTest.java
@@ -35,29 +35,29 @@ public class AccountUserDetailsServiceTest {
     	account.setUserName("加藤健");
     	account.setPassword("pinballs");
     	account.setRole("ROLE_USER");
-    	when(loginmapper.findAccount("加藤健")).thenReturn(account);
-    	when(loginmapper.findAccount("佐藤健")).thenReturn(null);
+    	when(loginmapper.findAccount("example@ezweb.ne.jp")).thenReturn(account);
+    	when(loginmapper.findAccount("hogehoge@gmail.com")).thenReturn(null);
     }
 	
 	@Test
     void loadUserByUsernameでユーザが一人見つかる() throws Exception{
-		AccountUserDetails details = (AccountUserDetails)accountUserDetailsService.loadUserByUsername("加藤健");
+		AccountUserDetails details = (AccountUserDetails)accountUserDetailsService.loadUserByUsername("example@ezweb.ne.jp");
 		assertEquals(true,details instanceof AccountUserDetails);
 		assertNotNull(details.getAccount());
 		assertEquals(details.getUsername(),"加藤健");
 		assertEquals(details.getPassword(),"pinballs");
 		assertEquals(details.getAuthorities().toString(),"[ROLE_USER]");
-		verify(loginmapper,times(1)).findAccount("加藤健");
+		verify(loginmapper,times(1)).findAccount("example@ezweb.ne.jp");
 	}
 	
 	@Test
     void loadUserByUsernameでユーザが見つからない場合に例外を投げる() throws Exception{
 		try{
-			accountUserDetailsService.loadUserByUsername("佐藤健");
+			accountUserDetailsService.loadUserByUsername("hogehoge@gmail.com");
 		} catch(UsernameNotFoundException e) {
 			assertEquals(e.getMessage(),"User not found.");
 		}
-		verify(loginmapper,times(1)).findAccount("佐藤健");
+		verify(loginmapper,times(1)).findAccount("hogehoge@gmail.com");
 	}
 
 }

--- a/src/test/java/com/dining/boyaki/model/service/conbined/AccountUserDetailsServiceCombinedTest.java
+++ b/src/test/java/com/dining/boyaki/model/service/conbined/AccountUserDetailsServiceCombinedTest.java
@@ -33,7 +33,7 @@ public class AccountUserDetailsServiceCombinedTest {
 	@Test
 	@DatabaseSetup(value="/service/AccountUserDetails/setup/")
     void loadUserByUsernameでユーザが一人見つかる() throws Exception{
-		AccountUserDetails details = (AccountUserDetails)accountUserDetailsService.loadUserByUsername("加藤健");
+		AccountUserDetails details = (AccountUserDetails)accountUserDetailsService.loadUserByUsername("example@ezweb.ne.jp");
 		assertEquals(true,details instanceof AccountUserDetails);
 		assertNotNull(details.getAccount());
 		assertEquals("加藤健",details.getUsername());
@@ -45,7 +45,7 @@ public class AccountUserDetailsServiceCombinedTest {
 	@DatabaseSetup(value="/service/AccountUserDetails/setup/")
     void loadUserByUsernameでユーザが見つからない場合に例外を投げる() throws Exception{
 		try{
-			accountUserDetailsService.loadUserByUsername("佐藤健");
+			accountUserDetailsService.loadUserByUsername("hogehoge@gmail.com");
 		} catch(UsernameNotFoundException e) {
 			assertEquals(e.getMessage(),"User not found.");
 		}


### PR DESCRIPTION
LoginMapperを修正
WebSecurityConfigとLogin.htmlのusernameParameterを、nameからmailに変更
LoginMapper,AccountUserDetailsService,LoginControllerのテストコードを修正